### PR TITLE
improve login screen

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,13 +1,52 @@
 import * as React from 'react'
-import { css, StyleAttribute } from 'glamor'
+import { Component } from 'react'
+import { css } from 'glamor'
 import withData from '../lib/withData'
+import withMe from '../lib/withMe'
 import App from '../components/App'
 import SignIn from '../components/Auth/SignIn'
+import { Body, Content } from '../components/Layout'
+import { Interaction, Logo } from '@project-r/styleguide'
+import { Router } from '../routes'
 
-export default withData((props: any) => {
-  return (
-    <App>
-      <SignIn />
-    </App>
-  )
-})
+const styles = {
+  center: css({
+    width: '100%',
+    maxWidth: '500px',
+    margin: '20vh auto'
+  })
+}
+
+const goToUsers = ({ me }: any) => {
+  if (me) {
+    Router.replaceRoute('users')
+  }
+}
+
+class Index extends Component<AnyObject, AnyObject> {
+  componentDidUpdate() {
+    goToUsers(this.props)
+  }
+  componentDidMount() {
+    goToUsers(this.props)
+  }
+  render() {
+    return (
+      <App>
+        <Body>
+          <Content>
+            <div {...styles.center}>
+              <div style={{ maxWidth: 300, marginBottom: 60 }}>
+                <Logo />
+                <Interaction.H2>Admin</Interaction.H2>
+              </div>
+              <SignIn />
+            </div>
+          </Content>
+        </Body>
+      </App>
+    )
+  }
+}
+
+export default withData(withMe(Index))

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -23,6 +23,10 @@ const goToUsers = ({ me }: any) => {
   }
 }
 
+interface AnyObject {
+  [key: string]: any
+}
+
 class Index extends Component<AnyObject, AnyObject> {
   componentDidUpdate() {
     goToUsers(this.props)

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -8,3 +8,4 @@ routes
   .add('user', '/users/:userId', 'user')
 
 export default routes
+export const Router = routes.Router


### PR DESCRIPTION
<img width="624" alt="screen shot 2017-07-20 at 22 02 33" src="https://user-images.githubusercontent.com/410211/28436468-5a78aada-6d97-11e7-9cd7-5a268c874d54.png">

The ideal solution would be to have an HOC around every page which shows an login or unauthorized screen unless a me with the right role is present. The client side `replaceRoute` in the index page is just a temporary solution.