### PR TITLE
Fix: Subscribe/Unsubscribe Newsletter

### DIFF
--- a/components/Users/Detail/NewsletterForm.js
+++ b/components/Users/Detail/NewsletterForm.js
@@ -134,13 +134,11 @@ const mutation = gql`
     $userId: ID!
     $name: NewsletterName!
     $subscribed: Boolean!
-    $status: String!
   ) {
     updateNewsletterSubscription(
       userId: $userId
       name: $name
       subscribed: $subscribed
-      status: $status
     ) {
       id
       name


### PR DESCRIPTION
This Pull Request fixes broken subscribe and unsubscribe to newsletters. [`status` prop does not exist (anymore?)](https://github.com/orbiting/backends/blob/master/servers/republik/graphql/schema.js#L110-L120)

This allows Careteam to subscribe and unsubscribe a user on their behalf to available newsletters.