### PR TITLE
Display utils

### DIFF
--- a/components/Display/utils.js
+++ b/components/Display/utils.js
@@ -1,0 +1,129 @@
+import { css, merge } from 'glamor'
+import { fontStyles, colors } from '@project-r/styleguide'
+import { swissTime } from '../../lib/utils/formats'
+
+export const displayStyles = {
+  section: css({
+    padding: '10px 10px',
+    margin: '10px 10px',
+    backgroundColor: '#fff',
+    position: 'relative'
+  }),
+  interactiveSection: css({
+    transition: 'background-color 0.2s',
+    '& .show-on-focus': {
+      transition: 'opacity 0.2s',
+      opacity: 0
+    },
+    '&:focus, &:hover': {
+      outline: 'none',
+      backgroundColor: colors.secondaryBg,
+      '& .show-on-focus': {
+        opacity: 1
+      }
+    }
+  }),
+  sectionTitle: css({
+    ...fontStyles.sansSerifRegular23,
+    margin: '0 0 15px 0'
+  }),
+  sectionSubhead: css({
+    ...fontStyles.sansSerifMedium16,
+    margin: '6px 0 8px 0'
+  }),
+  sectionMenu: css({
+    position: 'absolute',
+    top: '10px',
+    right: '20px'
+  }),
+  hFlexBox: css({
+    display: 'flex',
+    flexDirection: 'row',
+    '& > *:not(:last-child)': {
+      marginRight: '40px'
+    }
+  }),
+  definitionList: css({
+    margin: '9px 0 9px 0'
+  }),
+  definitionTitle: css({
+    ...fontStyles.label,
+    lineHeight: '18px',
+    '&:not(:first-child)': {
+      marginTop: '18px'
+    }
+  }),
+  definition: css({
+    ...fontStyles.sansSerifRegular18
+  }),
+  plainButton: css({
+    cursor: 'pointer',
+    display: 'inline-block',
+    outline: 'none',
+    background: 'none',
+    border: 'none',
+    padding: '0',
+    transition: 'color 0.1s',
+    '&:not([disabled]):focus, &:hover': {
+      color: colors.primary
+    },
+    '&[disabled]': {
+      color: colors.disabled
+    }
+  })
+}
+
+const dateFormat = swissTime.format('%d.%m.%Y')
+export const displayDate = rawDate => {
+  return dateFormat(new Date(rawDate))
+}
+
+const dateTimeFormat = swissTime.format(
+  '%d.%m.%Y, %H:%m Uhr'
+)
+export const displayDateTime = rawDate => {
+  return dateTimeFormat(new Date(rawDate))
+}
+
+export const Section = props => (
+  <div {...props} {...displayStyles.section} />
+)
+
+export const InteractiveSection = props => (
+  <div
+    {...props}
+    tabIndex="0"
+    {...merge(
+      displayStyles.section,
+      displayStyles.interactiveSection
+    )}
+  />
+)
+
+export const SectionTitle = props => (
+  <h4 {...props} {...displayStyles.sectionTitle} />
+)
+
+export const SectionSubhead = props => (
+  <h5 {...props} {...displayStyles.sectionSubhead} />
+)
+
+export const SectionMenu = props => (
+  <div {...props} {...displayStyles.sectionMenu} />
+)
+
+export const PlainButton = props => (
+  <button {...props} {...displayStyles.plainButton} />
+)
+
+export const DL = props => (
+  <div {...props} {...displayStyles.definitionList} />
+)
+
+export const DT = props => (
+  <div {...props} {...displayStyles.definitionTitle} />
+)
+
+export const DD = props => (
+  <div {...props} {...displayStyles.definition} />
+)

--- a/components/InlineOverlay.js
+++ b/components/InlineOverlay.js
@@ -1,0 +1,48 @@
+import { Component } from 'react'
+import { createPortal } from 'react-dom'
+import { css } from 'glamor'
+
+const styles = {
+  overlay: css({
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+    backgroundColor: '#fff',
+    zIndex: '10'
+  })
+}
+
+class Portal extends Component {
+  componentWillUnmount() {
+    if (this.defaultNode) {
+      document.body.removeChild(this.defaultNode)
+    }
+    this.defaultNode = null
+  }
+
+  render() {
+    if (!process.browser) {
+      return null
+    }
+    if (!this.props.node && !this.defaultNode) {
+      this.defaultNode = document.createElement('div')
+      document.body.appendChild(this.defaultNode)
+    }
+    return createPortal(
+      this.props.children,
+      this.props.node || this.defaultNode
+    )
+  }
+}
+
+export default ({ children }) => {
+  return (
+    <Portal
+      node={document && document.getElementById('content')}
+    >
+      <div {...styles.overlay}>{children}</div>
+    </Portal>
+  )
+}

--- a/components/Tables/utils.js
+++ b/components/Tables/utils.js
@@ -35,6 +35,27 @@ export const tableStyles = {
       zIndex: 10
     }
   }),
+  selectableRow: css({
+    '& td': {
+      transition: 'border-color 0.2s',
+      borderTop: `1px solid ${colors.secondary}00`,
+      borderBottom: `1px solid ${colors.secondary}00`
+    },
+    '&[data-active="true"] td': {
+      transition: 'none',
+      borderColor: colors.secondary
+    },
+    '&:hover, &[data-active="true"]': {
+      color: colors.primary
+    },
+    transition: 'color 0.2s',
+    cursor: 'pointer'
+  }),
+  emphasisedRow: css({
+    '& td': {
+      borderBottom: `1px solid ${colors.divider}`
+    }
+  }),
   left: css({
     textAlign: 'left'
   }),
@@ -43,6 +64,9 @@ export const tableStyles = {
   }),
   center: css({
     textAlign: 'center'
+  }),
+  paddedCell: css({
+    padding: '15px 2px'
   })
 }
 
@@ -62,12 +86,6 @@ export const createChangeHandler = (params, handler) => (
     delete params[fieldName]
     handler(params)
   }
-}
-
-export const displayDate = rawDate => {
-  const date = new Date(rawDate)
-  return `${date.getDate()}.${date.getMonth() +
-    1}.${date.getFullYear()}`
 }
 
 export const createSortHandler = (
@@ -95,9 +113,7 @@ export const createSortIndicator = sort => fieldName => {
   }
 }
 
-export const deserializeOrderBy = (
-  str
-) => {
+export const deserializeOrderBy = str => {
   if (!str) {
     return
   }
@@ -108,7 +124,5 @@ export const deserializeOrderBy = (
   }
 }
 
-export const serializeOrderBy = ({
-  field,
-  direction
-}) => `${field}-${direction}`
+export const serializeOrderBy = ({ field, direction }) =>
+  `${field}-${direction}`


### PR DESCRIPTION
A collection of helpers to supplement styleguide components when smaller fonts are needed in tables and overview components.

- `components/Display/utils`: Styles and helpers for general record display.
- `components/Table/utils`: Styles and helpers for tabular data display.
- `components/InlineOverlay`: Use instead of styleguide overlay to get a fullscreen overlay for larger forms or similar.