### PR TITLE
Display more verbose state about membership in Detail/MembershipOverview

### DIFF
--- a/components/Users/Detail/MembershipOverview.js
+++ b/components/Users/Detail/MembershipOverview.js
@@ -18,26 +18,42 @@ const dateTimeFormat = swissTime.format(
   '%e. %B %Y %H.%M Uhr'
 )
 
+const getState = (membership) => {
+  if (!membership.active) {
+    return 'deaktiviert'
+  }
+
+  if (!membership.renew) {
+    return 'aktiv, läuft aus'
+  }
+
+  const latestPeriod = membership.periods.reduce((acc, curr) => {
+    return acc && new Date(acc.endDate) > new Date(curr.endDate) ? acc : curr
+  })
+
+  const overdue = latestPeriod && new Date(latestPeriod.endDate) < new Date()
+  if (overdue) {
+    return 'aktiv, Erneuerung überfällig'
+  }
+
+  return 'aktiv'
+
+}
+
 const MembershipOverview = ({
   membership,
   onMoveMembership,
   onReactivateMembership,
   onCancelMembership
 }) => {
+
   return (
     <div>
       <Interaction.H3>
         {membership.type.name.split('_').join(' ')} –{' '}
-        {dateTimeFormat(new Date(membership.createdAt))} –{' '}
-        {(!!membership.renew && 'ACTIVE') || 'INACTIVE'}
+        {dateTimeFormat(new Date(membership.createdAt))}
         <br />
-        <Label>
-          Created:{' '}
-          {dateTimeFormat(new Date(membership.createdAt))}
-          {' – '}
-          Updated:{' '}
-          {dateTimeFormat(new Date(membership.updatedAt))}
-        </Label>
+        {getState(membership)}
       </Interaction.H3>
       <List>
         {membership.cancellations &&


### PR DESCRIPTION
Fixes ACTIVE/INACTIVE in membership heading. Distinguishes between:

* _active_ ("aktiv") if all is green an good and shiny
* _active, overdue_ ("aktiv, Erneuerung überfällig") if membership is active without any period
* _active, expiring_ ("aktiv, läuft aus") if membership got cancelled
* _deactivated_ ("deaktiviert") if membership is deactivated

<img width="587" alt="bildschirmfoto 2019-01-14 um 08 02 50" src="https://user-images.githubusercontent.com/331800/51099768-df64b180-17d2-11e9-826d-28f43f13fd2d.png">