### PR TITLE
Show Payment.createdAt in Users/Pledges

### DIFF
--- a/components/Users/Pledges/index.js
+++ b/components/Users/Pledges/index.js
@@ -78,7 +78,6 @@ const GET_PLEDGES = gql`
           dueDate
           remindersSentAt
           createdAt
-          updatedAt
         }
         package {
           name
@@ -297,6 +296,7 @@ const PaymentDetails = ({ payment, ...props}) => {
         {payment.method !== 'STRIPE' && payment.method}
         {' - '} {payment.status}
       </SectionSubhead>
+      <Label>Erstellt am {displayDateTime(new Date(payment.createdAt))}</Label>
       <div {...displayStyles.hFlexBox}>
         <div>
           <DL>


### PR DESCRIPTION
Shows payment `createdAt` as a well-formatted string.

<img width="454" alt="bildschirmfoto 2019-03-04 um 09 14 38" src="https://user-images.githubusercontent.com/331800/53719419-465f2800-3e5e-11e9-91fe-3715813608a3.png">

Fixes #34 