### PR TITLE
feat: Query and show mailLog and User.mailLog

### DIFF
--- a/components/Layout/Header.js
+++ b/components/Layout/Header.js
@@ -85,6 +85,14 @@ export default ({ ...props }) => {
               Users
             </a>
           </Link>
+          <Link route="maillog" params={searchParams}>
+            <a
+              className={`${link}`}
+              style={navLinkStyles}
+            >
+              E-Mails
+            </a>
+          </Link>
           <Link route="payments" params={searchParams}>
             <a
               className={`${link}`}

--- a/components/MailLog/List.js
+++ b/components/MailLog/List.js
@@ -1,0 +1,72 @@
+import {
+  Label,
+  A
+} from '@project-r/styleguide'
+
+import routes from '../../server/routes'
+
+import { displayDateTime } from '../Display/utils'
+import { tableStyles } from '../Tables/utils'
+
+import Status from './Status'
+
+const { Link } = routes
+
+const List = ({ nodes }) => (
+  <table {...tableStyles.table}>
+    <colgroup>
+      <col style={{ width: '15%' }} />
+      <col style={{ width: '25%' }} />
+      <col style={{ width: '50%' }} />
+      <col style={{ width: '10%' }} />
+    </colgroup>
+    <tbody>
+      {nodes.map(mail => (
+        <tr key={mail.id} {...tableStyles.row}>
+          <td {...tableStyles.paddedCell}>
+            {displayDateTime(mail.createdAt)}
+            <Status status={mail.status} error={mail.error} />
+          </td>
+          <td {...tableStyles.paddedCell}>
+            {mail.user 
+              ? <>
+                <Link
+                  route='user'
+                  params={{userId: mail.user.id}}
+                  passHref>
+                  <A>
+                    {`${mail.user.name} (${mail.email})`}
+                  </A>
+                </Link>
+              </>
+              : mail.email
+            }
+          </td>
+          <td {...tableStyles.paddedCell}>
+            {mail.subject
+              ? <>
+                <div>{mail.subject}</div>
+                <Label>{mail.template || mail.type} · ID: {mail.id}</Label>
+              </>
+              : <>
+                <div>{mail.template || mail.type}</div>
+                <Label>ID: {mail.id}</Label>
+              </>
+            }
+          </td>
+          <td>
+            {mail.mandrill && mail.mandrill.map(({ label, url }) => (
+              <div>
+                <A key={`${label}-${url}`} href={url} target="_blank">
+                  {label}
+                </A>
+              </div>
+            ))}
+          </td>
+        </tr>
+      ))}
+    </tbody>
+  </table>
+)
+
+export default List

--- a/components/MailLog/Page.js
+++ b/components/MailLog/Page.js
@@ -1,0 +1,70 @@
+import { Query } from 'react-apollo'
+import gql from 'graphql-tag'
+
+import withT from '../../lib/withT'
+
+import {
+  Label,
+  Loader,
+  A
+} from '@project-r/styleguide'
+
+import {
+  displayDateTime,
+  Section,
+  SectionTitle
+} from '../Display/utils'
+
+import { tableStyles } from '../Tables/utils'
+import routes from '../../server/routes'
+import List from './List'
+
+const { Link } = routes
+
+const GET_MAILLOG = gql`
+query getMailLog {
+  mailLog(first: 100) {
+    nodes {
+      id
+      email
+      type
+      template
+      subject
+      createdAt
+      status
+      error
+      mandrill {
+        label
+        url
+      }
+      user {
+        id
+        name
+      }
+    }
+  }
+}
+`
+
+const Page = withT(({ userId }) => {
+  return (
+    <Query query={GET_MAILLOG} variables={{id: userId}}>{({loading, error, data}) => {
+      return (
+        <Loader
+          loading={loading}
+          error={error}
+          render={() =>
+            <Section>
+              <SectionTitle>
+                E-Mails
+              </SectionTitle>
+              <List nodes={data.mailLog.nodes} />
+            </Section>
+          }
+        />
+      )
+    }}</Query>
+  )
+})
+
+export default Page

--- a/components/MailLog/Status.js
+++ b/components/MailLog/Status.js
@@ -7,6 +7,7 @@ import {
   colors,
   Interaction,
   A,
+  Label,
   Overlay,
   OverlayToolbar,
   OverlayToolbarClose,
@@ -54,13 +55,18 @@ export default class Status extends Component {
 
     return (
       <>
-        {!['sent', 'sent-simulated'].includes(status) && (
+        {status !== 'sent' && error && (
           <div>
             <A href='#' onClick={this.openHandler}>
               <span {...styles.error}>
                 <MdError size='1.2em' {...styles.icon} /> Problem
               </span>
             </A>
+          </div>
+        )}
+        {status !== 'sent' && !error && (
+          <div>
+            <Label>{status}</Label>
           </div>
         )}
         {isOpen && (

--- a/components/MailLog/Status.js
+++ b/components/MailLog/Status.js
@@ -1,0 +1,85 @@
+import { Component } from 'react'
+import { css } from 'glamor'
+
+import { MdError } from 'react-icons/md'
+
+import {
+  colors,
+  Interaction,
+  A,
+  Overlay,
+  OverlayToolbar,
+  OverlayToolbarClose,
+  OverlayBody
+} from '@project-r/styleguide'
+
+const {
+  H2,
+  H3,
+  P
+} = Interaction
+
+const styles = {
+  error: css({
+    color: colors.error
+  }),
+  icon: css({
+    verticalAlign: 'baseline',
+    marginRight: 3,
+    marginBottom: '-0.2em'
+  })
+}
+
+export default class Status extends Component {
+  constructor(props) {
+    super(props)
+  
+    this.state = {
+      isOpen: false
+    }
+
+    this.openHandler = e => {
+      e.preventDefault()
+      this.setState(() => ({ isOpen: true }))
+    }
+  
+    this.closeHandler = () => {
+      this.setState(() => ({ isOpen: false }))
+    }
+  }
+
+  render() {
+    const { status, error } = this.props
+    const { isOpen } = this.state
+
+    return (
+      <>
+        {!['sent', 'sent-simulated'].includes(status) && (
+          <div>
+            <A href='#' onClick={this.openHandler}>
+              <span {...styles.error}>
+                <MdError size='1.2em' {...styles.icon} /> Problem
+              </span>
+            </A>
+          </div>
+        )}
+        {isOpen && (
+          <Overlay onClose={this.closeHandler}>
+            <OverlayToolbar>
+              <OverlayToolbarClose onClick={this.closeHandler} />
+            </OverlayToolbar>
+
+            <OverlayBody>
+              <H2><MdError size='1.2em' {...styles.icon} /> Problem</H2>
+              <br />
+              <H3>Status: {status}</H3>
+              <br />
+              <P>Fehlermeldung: {error}</P>
+            </OverlayBody>
+          </Overlay>
+        )}
+      </>
+    )
+  }
+}
+

--- a/components/Users/MailLog.js
+++ b/components/Users/MailLog.js
@@ -1,0 +1,64 @@
+import { Query } from 'react-apollo'
+import gql from 'graphql-tag'
+
+import withT from '../../lib/withT'
+
+import {
+  Label,
+  Loader
+} from '@project-r/styleguide'
+
+import {
+  displayDateTime,
+  Section,
+  SectionTitle
+} from '../Display/utils'
+
+import List from '../MailLog/List'
+
+const GET_USER_MAILLOG = gql`
+query getUserMailLog($id: String) {
+  user(slug: $id) {
+    id
+    mailLog {
+      nodes {
+        id
+        email
+        type
+        template
+        subject
+        createdAt
+        status
+        error
+        mandrill {
+          label
+          url
+        }
+      }
+    }
+  }
+}
+`
+
+const MailLog = withT(({ userId }) => {
+  return (
+    <Query query={GET_USER_MAILLOG} variables={{id: userId}}>{({loading, error, data}) => {
+      return (
+        <Loader
+          loading={loading}
+          error={error}
+          render={() =>
+            <Section>
+              <SectionTitle>
+                E-Mails
+              </SectionTitle>
+              <List nodes={data.user.mailLog.nodes} />
+            </Section>
+          }
+        />
+      )
+    }}</Query>
+  )
+})
+
+export default MailLog

--- a/components/Users/ProfileHeader.js
+++ b/components/Users/ProfileHeader.js
@@ -10,6 +10,7 @@ import {
 } from '@project-r/styleguide'
 
 import routes from '../../server/routes'
+import { REPUBLIK_FRONTEND_URL } from '../../server/constants'
 
 import { Section } from '../Display/utils'
 const { Link } = routes
@@ -94,6 +95,20 @@ const Subnav = ({ userId, section }) => (
         Access Grants
       </a>
     </Link>
+    <Link
+      route='user'
+      params={{
+        userId,
+        section: 'maillog'
+      }}
+    >
+      <a
+        {...styles.navLink}
+        data-active={section === 'maillog'}
+      >
+        E-Mails
+      </a>
+    </Link>
   </div>
 )
 
@@ -128,7 +143,9 @@ export default ({ userId, section }) => {
                 ),
                 user.username && (
                   <span key="username">
-                    {user.username}
+                    <A key="profile" href={`${REPUBLIK_FRONTEND_URL}/~${user.username}`} target="_blank">
+                      {user.username}
+                    </A>
                   </span>
                 )
               ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -4971,8 +4971,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": false,
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "optional": true
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "aproba": {
           "version": "1.2.0",
@@ -4993,14 +4992,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "resolved": false,
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "optional": true
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5009,20 +5006,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "resolved": false,
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "optional": true
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "optional": true
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "optional": true
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5130,8 +5124,7 @@
         "inherits": {
           "version": "2.0.3",
           "resolved": false,
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "optional": true
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
           "version": "1.3.5",
@@ -5143,7 +5136,6 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5158,7 +5150,6 @@
           "version": "3.0.4",
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5254,8 +5245,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "resolved": false,
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "optional": true
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5267,7 +5257,6 @@
           "version": "1.4.0",
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5353,8 +5342,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "resolved": false,
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "optional": true
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5390,7 +5378,6 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5410,7 +5397,6 @@
           "version": "3.0.1",
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5439,8 +5425,7 @@
         "wrappy": {
           "version": "1.0.2",
           "resolved": false,
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "optional": true
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         }
       }
     },
@@ -6771,7 +6756,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.4.0.tgz",
       "integrity": "sha512-6PmOuSP4NnZXzs2z6rbwzLJu/c5gdzYg1mRI/WIYdx45iiX7T+a4esOzavD6V/KmBzAaopFSTZPZcUx73bqKWA==",
-      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -6780,14 +6764,12 @@
         "safe-buffer": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
-          "optional": true
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "optional": true
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
         }
       }
     },

--- a/pages/maillog.js
+++ b/pages/maillog.js
@@ -1,0 +1,37 @@
+import React from 'react'
+import { compose } from 'react-apollo'
+import { withRouter } from 'next/router'
+
+import App from '../components/App'
+import { enforceAuthorization } from '../components/Auth/withAuthorization'
+
+import {
+  Body,
+  Content,
+  Header
+} from '../components/Layout'
+import MailLogPage from '../components/MailLog/Page'
+import { Router } from '../server/routes'
+
+const changeHandler = params => {
+  Router.replaceRoute('maillog', params, { shallow: true })
+}
+
+export default compose(
+  withRouter,
+  enforceAuthorization(['supporter'])
+)(props => {
+  return (
+    <App>
+      <Body>
+        <Header search={props.router.query.search} />
+        <Content id='content'>
+          <MailLogPage
+            params={props.router.query}
+            onChange={changeHandler}
+          />
+        </Content>
+      </Body>
+    </App>
+  )
+})

--- a/pages/user.js
+++ b/pages/user.js
@@ -22,7 +22,8 @@ import LatestActivity from '../components/Users/LatestActivity'
 import EventLog from '../components/Users/EventLog'
 import Access from '../components/Users/Access'
 import Sessions from '../components/Users/Sessions'
-import Actions from '../components/Users/Actions';
+import Actions from '../components/Users/Actions'
+import MailLog from '../components/Users/MailLog'
 
 const styles = {
   row: css({
@@ -41,6 +42,9 @@ const styles = {
 const SectionSwitch = ({ userId, section }) => {
   if (section === 'access-grants') {
     return <Access userId={userId} />
+  }
+  if (section === 'maillog') {
+    return <MailLog userId={userId} />
   }
   if (section === 'sessions') {
     return <Fragment>

--- a/server/routes.js
+++ b/server/routes.js
@@ -3,6 +3,7 @@ const routes = createRoutes()
 
 routes
   .add('users')
+  .add('maillog')
   .add('payments')
   .add('postfinance-payments')
   .add('merge-users')


### PR DESCRIPTION
Queries `mailLog` and `User.mailLog` and shows it somewhat nicely.

Last emails:

<img width="1165" alt="Bildschirmfoto 2020-01-06 um 11 09 43" src="https://user-images.githubusercontent.com/331800/71811794-dcaf3c00-3075-11ea-8395-e3ea87fb2131.png">

Last emails per User:

<img width="1162" alt="User E-Mails" src="https://user-images.githubusercontent.com/331800/71811807-e2a51d00-3075-11ea-8a5a-a63ae2e6afaa.png">

«Problem» Overlay:

<img width="600" alt="Problem" src="https://user-images.githubusercontent.com/331800/71811821-ee90df00-3075-11ea-8ec6-4b9dcf4bbf35.png">

Depends on https://github.com/orbiting/backends/pull/358