### PR TITLE
Add pagination to maillog lists and show on user "dashboard"

### DIFF
--- a/components/MailLog/List.js
+++ b/components/MailLog/List.js
@@ -12,14 +12,21 @@ import Status from './Status'
 
 const { Link } = routes
 
-const List = ({ nodes }) => (
+const List = ({ nodes, narrow = false }) => (
   <table {...tableStyles.table}>
-    <colgroup>
-      <col style={{ width: '15%' }} />
-      <col style={{ width: '25%' }} />
-      <col style={{ width: '50%' }} />
-      <col style={{ width: '10%' }} />
-    </colgroup>
+    {!narrow ? (
+      <colgroup>
+        <col style={{ width: '15%' }} />
+        <col style={{ width: '25%' }} />
+        <col style={{ width: '50%' }} />
+        <col style={{ width: '10%' }} />
+      </colgroup>
+    ) : (
+      <colgroup>
+        <col style={{ width: '30%' }} />
+        <col style={{ width: '70%' }} />
+      </colgroup>
+    )}
     <tbody>
       {nodes.map(mail => (
         <tr key={mail.id} {...tableStyles.row}>
@@ -27,26 +34,31 @@ const List = ({ nodes }) => (
             {displayDateTime(mail.createdAt)}
             <Status status={mail.status} error={mail.error} />
           </td>
-          <td {...tableStyles.paddedCell}>
-            {mail.user 
-              ? <>
-                <Link
-                  route='user'
-                  params={{userId: mail.user.id}}
-                  passHref>
-                  <A>
-                    {`${mail.user.name} (${mail.email})`}
-                  </A>
-                </Link>
-              </>
-              : mail.email
-            }
-          </td>
+          {!narrow && (
+            <td {...tableStyles.paddedCell}>
+              {mail.user 
+                ? <>
+                  <Link
+                    route='user'
+                    params={{userId: mail.user.id}}
+                    passHref>
+                    <A>
+                      {`${mail.user.name} (${mail.email})`}
+                    </A>
+                  </Link>
+                </>
+                : mail.email
+              }
+            </td>
+          )}
           <td {...tableStyles.paddedCell}>
             {mail.subject
               ? <>
                 <div>{mail.subject}</div>
-                <Label>{mail.template || mail.type} · ID: {mail.id}</Label>
+                <Label>
+                  {mail.template || mail.type}
+                  {!narrow && <> · ID: {mail.id}</>}
+                </Label>
               </>
               : <>
                 <div>{mail.template || mail.type}</div>
@@ -54,15 +66,17 @@ const List = ({ nodes }) => (
               </>
             }
           </td>
-          <td>
-            {mail.mandrill && mail.mandrill.map(({ label, url }) => (
-              <div>
-                <A key={`${label}-${url}`} href={url} target="_blank">
-                  {label}
-                </A>
-              </div>
-            ))}
-          </td>
+          {!narrow && (
+            <td>
+              {mail.mandrill && mail.mandrill.map(({ label, url }) => (
+                <div key={`${label}-${url}`}>
+                  <A href={url} target="_blank">
+                    {label}
+                  </A>
+                </div>
+              ))}
+            </td>
+          )}
         </tr>
       ))}
     </tbody>

--- a/pages/user.js
+++ b/pages/user.js
@@ -66,7 +66,6 @@ const SectionSwitch = ({ userId, section }) => {
     <div {...styles.fifty}>
       <AuthSettings userId={userId} />
       <MailLog userId={userId} narrow={2} />
-      <LatestActivity userId={userId} />
       <AdminNotes userId={userId} />
     </div>
     <div {...styles.fifty}>

--- a/pages/user.js
+++ b/pages/user.js
@@ -65,6 +65,7 @@ const SectionSwitch = ({ userId, section }) => {
     </div>
     <div {...styles.fifty}>
       <AuthSettings userId={userId} />
+      <MailLog userId={userId} narrow={2} />
       <LatestActivity userId={userId} />
       <AdminNotes userId={userId} />
     </div>


### PR DESCRIPTION
Show narrow and shortened list on user "dashboard":

<img width="668" alt="Bildschirmfoto 2020-01-08 um 01 05 41" src="https://user-images.githubusercontent.com/331800/71939495-22bdea00-31b3-11ea-937a-28b6f08fecf6.png">

Load "more"...

<img width="1173" alt="Bildschirmfoto 2020-01-08 um 01 06 04" src="https://user-images.githubusercontent.com/331800/71939494-22bdea00-31b3-11ea-985b-b1b8947d623f.png">
