### PR TITLE
feat(MailLog): Query for errornous mail log records only

### DIFF
--- a/components/Display/utils.js
+++ b/components/Display/utils.js
@@ -36,6 +36,9 @@ export const displayStyles = {
     top: '10px',
     right: '20px'
   }),
+  sectionNav: css({
+    margin: '0 0 15px 0'
+  }),
   hFlexBox: css({
     display: 'flex',
     flexDirection: 'row',
@@ -108,6 +111,10 @@ export const SectionTitle = props => (
 
 export const SectionSubhead = props => (
   <h5 {...props} {...displayStyles.sectionSubhead} />
+)
+
+export const SectionNav = props => (
+  <nav {...props} {...displayStyles.sectionNav} />
 )
 
 export const SectionMenu = props => (

--- a/components/MailLog/List.js
+++ b/components/MailLog/List.js
@@ -5,7 +5,7 @@ import {
 
 import routes from '../../server/routes'
 
-import { displayDateTime } from '../Display/utils'
+import { displayDateTime, displayDate } from '../Display/utils'
 import { tableStyles } from '../Tables/utils'
 
 import Status from './Status'
@@ -38,14 +38,17 @@ const List = ({ nodes, narrow = false }) => (
             <td {...tableStyles.paddedCell}>
               {mail.user 
                 ? <>
-                  <Link
-                    route='user'
-                    params={{userId: mail.user.id}}
-                    passHref>
-                    <A>
-                      {`${mail.user.name} (${mail.email})`}
-                    </A>
-                  </Link>
+                  <div>
+                    <Link
+                      route='user'
+                      params={{userId: mail.user.id}}
+                      passHref>
+                      <A>
+                        {`${mail.user.name} (${mail.email})`}
+                      </A>
+                    </Link>
+                  </div>
+                  <Label>Created: {displayDate(mail.user.createdAt)}</Label>
                 </>
                 : mail.email
               }

--- a/components/MailLog/Page.js
+++ b/components/MailLog/Page.js
@@ -39,6 +39,7 @@ query getMailLog($after: String, $hasError: Boolean) {
       user {
         id
         name
+        createdAt
       }
     }
   }

--- a/components/MailLog/Page.js
+++ b/components/MailLog/Page.js
@@ -5,9 +5,7 @@ import withT from '../../lib/withT'
 
 import {
   Loader,
-  A,
-  P,
-  Interaction
+  A
 } from '@project-r/styleguide'
 
 import {
@@ -19,8 +17,8 @@ import {
 import List from './List'
 
 const GET_MAILLOG = gql`
-query getMailLog($after: String, $errornous: Boolean) {
-  mailLog(first: 100, after: $after, filters: { errornous: $errornous }) {
+query getMailLog($after: String, $hasError: Boolean) {
+  mailLog(first: 20, after: $after, filters: { hasError: $hasError }) {
     pageInfo {
       hasNextPage
       endCursor
@@ -48,17 +46,17 @@ query getMailLog($after: String, $errornous: Boolean) {
 `
 
 const Page = withT(({ params, onChange }) => {
-  const { errornous = false } = params
+  const { hasError = false } = params
 
   const toggleFilterErrornous = e => {
     e.preventDefault()
-    onChange({ ...params, errornous: !errornous ? true : null })
+    onChange({ ...params, hasError: !hasError ? true : null })
   }
 
   return (
-    <Query query={GET_MAILLOG} variables={{ errornous: !!errornous }}>{({ loading, error, data, fetchMore }) => {
+    <Query query={GET_MAILLOG} variables={{ hasError: !!hasError }}>{({ loading, error, data, fetchMore }) => {
       const fetchMoreNodes = () => fetchMore({
-        variables: { after: data.mailLog.pageInfo.endCursor, errornous },
+        variables: { after: data.mailLog.pageInfo.endCursor, hasError: !!hasError },
         updateQuery: (previousResult, { fetchMoreResult }) => ({
           mailLog: {
             __typename: previousResult.mailLog.__typename,
@@ -75,10 +73,10 @@ const Page = withT(({ params, onChange }) => {
           render={() =>
             <Section>
               <SectionTitle>
-                E-Mails {errornous && '(problematische Zustellungen)'}
+                E-Mails {hasError && '(problematische Zustellungen)'}
               </SectionTitle>
               <SectionNav>
-                <A href='#' onClick={toggleFilterErrornous}>{errornous ? 'Alle E-Mails' : 'Nur problematische Zustellungen'}</A>
+                <A href='#' onClick={toggleFilterErrornous}>{hasError ? 'Alle E-Mails' : 'Nur problematische Zustellungen'}</A>
               </SectionNav>
               <List nodes={data.mailLog.nodes} />
               {data.mailLog.pageInfo.endCursor && (


### PR DESCRIPTION
This Pull Requests enables to query mail log records for errornous records with a click:

![Bildschirmfoto 2020-05-04 um 14 50 52](https://user-images.githubusercontent.com/331800/80967722-1a9b5180-8e17-11ea-9655-7515ec76dac9.png)

![Bildschirmfoto 2020-05-04 um 14 51 09](https://user-images.githubusercontent.com/331800/80967731-1cfdab80-8e17-11ea-8d87-d3dbdf7fbaf3.png)

Depends on: https://github.com/orbiting/backends/pull/420