### PR TITLE
Allow autoPay mutation

### DIFF
--- a/components/Users/Memberships/index.js
+++ b/components/Users/Memberships/index.js
@@ -137,7 +137,7 @@ const autoPayOptions = [
   {value: 'false', text: 'No'}
 ]
 
-function AutoPayToggle (membership) {
+const AutoPayToggle = (membership) => {
 
   if (!membership.autoPayIsMutable) return (
     <React.Fragment>

--- a/components/Users/Memberships/index.js
+++ b/components/Users/Memberships/index.js
@@ -132,6 +132,11 @@ const SET_AUTO_PAY = gql`
   }
 `
 
+const autoPayOptions = [
+  {value: 'true', text: 'Yes'},
+  {value: 'false', text: 'No'}
+]
+
 function AutoPayToggle (membership) {
 
   if (!membership.autoPayIsMutable) return (
@@ -144,6 +149,9 @@ function AutoPayToggle (membership) {
       </DD>
     </React.Fragment>
   )
+
+  // Currently the dropdown component only supports string values
+  const autoPayAsString = membership.autoPay ? 'true' : 'false';
 
   return (
     <Mutation
@@ -170,8 +178,8 @@ function AutoPayToggle (membership) {
               <Dropdown
                 black
                 label=''
-                items={[{value: true, text: 'Yes'}, {value: false, text: 'No'}]}
-                value={membership.autoPay}
+                items={autoPayOptions}
+                value={autoPayAsString}
                 onChange={mutation}
               />
             </DD>

--- a/components/Users/Memberships/index.js
+++ b/components/Users/Memberships/index.js
@@ -170,7 +170,11 @@ const AutoPayToggle = (membership) => {
                 </React.Fragment>
               )}
             </DT>
-            <DD style={{position: 'relative'}}>
+            <DD style={{
+              position: 'relative',
+              pointerEvents: loading ? 'none' : 'auto'
+            }}
+            >
               { loading && (<Spinner/>) }
               <Dropdown
                 black

--- a/components/Users/Memberships/index.js
+++ b/components/Users/Memberships/index.js
@@ -154,10 +154,7 @@ const AutoPayToggle = (membership) => {
   const autoPayAsString = membership.autoPay ? 'true' : 'false';
 
   return (
-    <Mutation
-      mutation={SET_AUTO_PAY}
-      variables={{ id: membership.id, autoPay: !membership.autoPay }}
-    >
+    <Mutation mutation={SET_AUTO_PAY}>
       {(mutation, {loading, error}) => {
 
         return (
@@ -180,7 +177,12 @@ const AutoPayToggle = (membership) => {
                 label=''
                 items={autoPayOptions}
                 value={autoPayAsString}
-                onChange={mutation}
+                onChange={(item) => mutation({
+                  variables: {
+                    id: membership.id,
+                    autoPay: item.value === 'true'
+                  }
+                })}
               />
             </DD>
           </React.Fragment>


### PR DESCRIPTION
**This PR relies on the following backend PR: https://github.com/orbiting/backends/pull/455**

Yearly memberships have an `autoPay` option.

This PR allows for support users to modify the `autoPay` option on the `/users/:id` screen.

![Jun-26-2020 16-49-46](https://user-images.githubusercontent.com/46739/85870270-20853180-b7cd-11ea-860d-f0d57bb8fff0.gif)
![with errors](https://user-images.githubusercontent.com/46739/85870292-23802200-b7cd-11ea-9c46-4e4769c0e356.gif)
