### PR TITLE
Link HR-IDs w/ paymentslipUrl

### DIFF
--- a/components/Payments/List/Table.js
+++ b/components/Payments/List/Table.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Label, colors } from '@project-r/styleguide'
+import { A, Label, colors } from '@project-r/styleguide'
 import { chfFormat } from '../../../lib/utils/formats'
 import routes from '../../../server/routes'
 
@@ -130,7 +130,12 @@ const Table = ({ items, sort, onSort, ...props }) => {
                 {address && [address.line1, address.line2, [address.postalCode, address.city].join(' ')].filter(Boolean).join(', ')}
               </td>
               <td>{chfFormat(payment.total / 100)}</td>
-              <td>{payment.hrid}</td>
+              <td>
+                {payment.paymentslipUrl
+                  ? <A href={payment.paymentslipUrl} target='_blank'>{payment.hrid}</A>
+                  : payment.hrid
+                }
+              </td>
               <td>{payment.status}</td>
             </tr>
           )

--- a/components/Payments/List/index.js
+++ b/components/Payments/List/index.js
@@ -102,6 +102,7 @@ const paymentsQuery = gql`
         total
         status
         hrid
+        paymentslipUrl
         user {
           id
           name

--- a/components/Users/Pledges/index.js
+++ b/components/Users/Pledges/index.js
@@ -82,6 +82,7 @@ const GET_PLEDGES = gql`
           status
           method
           hrid
+          paymentslipUrl
           pspId
           paperInvoice
           dueDate
@@ -330,7 +331,12 @@ const PaymentDetails = ({ payment, ...props}) => {
             <DT>Total</DT>
             <DD>{chfFormat(payment.total / 100)}</DD>
             <DT>HR-ID</DT>
-            <DD>{payment.hrid}</DD>
+            <DD>
+              {payment.paymentslipUrl
+                ? <A href={payment.paymentslipUrl} target='_blank'>{payment.hrid}</A>
+                : payment.hrid
+              }
+            </DD>
           </DL>
         </div>
         {(payment.dueDate || payment.method) && (


### PR DESCRIPTION
This Pull Request links HR-IDs to PDF with QR code payment slip if available.

---

**Payments**

<img width="925" alt="Bildschirmfoto 2020-12-30 um 14 15 40" src="https://user-images.githubusercontent.com/331800/103353700-c6319a00-4aa9-11eb-99bd-c275a01edcda.png">

---

**User -> Pledges -> Payments**

<img width="663" alt="Bildschirmfoto 2020-12-30 um 14 16 05" src="https://user-images.githubusercontent.com/331800/103353719-d0539880-4aa9-11eb-9702-864c40ad486f.png">

Depends on https://github.com/orbiting/backends/pull/552