### PR TITLE
Add a button to reactivate the newsletter

### DIFF
--- a/components/Users/NewsletterSubscriptions.js
+++ b/components/Users/NewsletterSubscriptions.js
@@ -140,75 +140,69 @@ class UpdateSubscription extends Component {
   }
 }
 
-const NewsletterSubscriptions = ({ t, userId }) => {
-  const [colorScheme] = useColorContext()
+const NewsletterSubscriptions = ({ t, userId }) => (
+  <Query query={GET_NEWSLETTER_SUBSCRIPTION} variables={{ id: userId }}>
+    {({ data, loading, error }) => {
+      const isInitialLoading = loading && !(data && data.user)
+      return (
+        <Loader
+          loading={isInitialLoading}
+          error={error}
+          render={() => {
+            const { user } = data
+            const { subscriptions, status } = user.newsletterSettings
+            const hasNonEligibleSubscription = subscriptions.some(
+              newsletter => !newsletter.isEligible
+            )
 
-  return (
-    <Query query={GET_NEWSLETTER_SUBSCRIPTION} variables={{ id: userId }}>
-      {({ data, loading, error }) => {
-        const isInitialLoading = loading && !(data && data.user)
-        return (
-          <Loader
-            loading={isInitialLoading}
-            error={error}
-            render={() => {
-              const { user } = data
-              const { subscriptions, status } = user.newsletterSettings
-              const hasNonEligibleSubscription = subscriptions.some(
-                newsletter => !newsletter.isEligible
-              )
+            return (
+              <Section>
+                <SectionTitle>Abonnierte Newsletter</SectionTitle>
+                <div>
+                  <span style={{ marginRight: 10 }}>Status: {status}</span>
+                  {status !== 'subscribed' && (
+                    <Mutation mutation={RESUBSCRIBE_EMAIL}>
+                      {(mutate, { loading, error }) => {
+                        if (error) return <ErrorMessage error={error} />
 
-              return (
-                <Section>
-                  <SectionTitle>Abonnierte Newsletter</SectionTitle>
-                  <div>
-                    <span style={{ marginRight: 10 }}>Status: {status}</span>
-                    {status !== 'subscribed' && (
-                      <Mutation mutation={RESUBSCRIBE_EMAIL}>
-                        {(mutate, { loading, error }) => {
-                          if (error) return <ErrorMessage error={error} />
-
-                          return (
-                            <div>
-                              <TextButton
-                                disabled={loading}
-                                onClick={() => {
-                                  const answer = confirm(
-                                    'Wollen Sie die Newsletter für diesen Benutzer reaktivieren?\nDer Benutzer wird eine E-Mail erhalten, um die Reaktivierung zu bestätigen.'
-                                  )
-                                  if (answer)
-                                    mutate({ variables: { userId: user.id } })
-                                }}
-                              >
-                                <span {...colorScheme.set('color', 'primary')}>
-                                  reaktivieren
-                                </span>
-                              </TextButton>
-                              {loading && <InlineSpinner size={22} />}
-                            </div>
-                          )
-                        }}
-                      </Mutation>
-                    )}
-                  </div>
-                  {hasNonEligibleSubscription &&
-                    'Es können nur User mit aktiver Membership die Republik-Newsletter abonnieren.'}
-                  {subscriptions.map((subscription, index) => (
-                    <UpdateSubscription
-                      t={t}
-                      key={`${subscription.name}-${index}-${subscription.subscribed}`}
-                      user={user}
-                      subscription={subscription}
-                    />
-                  ))}
-                </Section>
-              )
-            }}
-          />
-        )
-      }}
-    </Query>
-  )
-}
+                        return (
+                          <div>
+                            <TextButton
+                              disabled={loading}
+                              onClick={() => {
+                                const answer = confirm(
+                                  'Wollen Sie die Newsletter für diesen Benutzer reaktivieren?\nDer Benutzer wird eine E-Mail erhalten, um die Reaktivierung zu bestätigen.'
+                                )
+                                if (answer)
+                                  mutate({ variables: { userId: user.id } })
+                              }}
+                            >
+                              reaktivieren
+                            </TextButton>
+                            {loading && <InlineSpinner size={22} />}
+                          </div>
+                        )
+                      }}
+                    </Mutation>
+                  )}
+                </div>
+                {hasNonEligibleSubscription &&
+                  'Es können nur User mit aktiver Membership die Republik-Newsletter abonnieren.'}
+                {subscriptions.map((subscription, index) => (
+                  <UpdateSubscription
+                    t={t}
+                    key={`${subscription.name}-${index}-${subscription.subscribed}`}
+                    user={user}
+                    subscription={subscription}
+                  />
+                ))}
+              </Section>
+            )
+          }}
+        />
+      )
+    }}
+  </Query>
+)
 
 export default withT(NewsletterSubscriptions)

--- a/components/Users/NewsletterSubscriptions.js
+++ b/components/Users/NewsletterSubscriptions.js
@@ -165,7 +165,7 @@ const NewsletterSubscriptions = ({ t, userId }) => {
                                 {...colorScheme.set('color', 'primary')}
                                 onClick={() => {
                                   const answer = confirm(
-                                    'Wollen Sie die Newsletter für diesen Benutzer reaktivieren?'
+                                    'Wollen Sie die Newsletter für diesen Benutzer reaktivieren?\nDer Benutzer wird eine E-Mail erhalten, um die Reaktivierung zu bestätigen.'
                                   )
                                   if (answer)
                                     mutate({ variables: { userId: user.id } })

--- a/components/Users/NewsletterSubscriptions.js
+++ b/components/Users/NewsletterSubscriptions.js
@@ -9,7 +9,6 @@ import {
   InlineSpinner,
   Loader,
   Checkbox,
-  useColorContext,
   ErrorMessage
 } from '@project-r/styleguide'
 

--- a/components/Users/NewsletterSubscriptions.js
+++ b/components/Users/NewsletterSubscriptions.js
@@ -17,7 +17,16 @@ import { Section, SectionTitle, TextButton } from '../Display/utils'
 
 export const RESUBSCRIBE_EMAIL = gql`
   mutation resubscribeEmail($userId: ID!) {
-    resubscribeEmail(userId: $userId)
+    resubscribeEmail(userId: $userId) {
+      id
+      status
+      subscriptions {
+        id
+        name
+        subscribed
+        isEligible
+      }
+    }
   }
 `
 
@@ -42,6 +51,7 @@ export const GET_NEWSLETTER_SUBSCRIPTION = gql`
     user(slug: $id) {
       id
       newsletterSettings {
+        id
         status
         subscriptions {
           id

--- a/components/Users/NewsletterSubscriptions.js
+++ b/components/Users/NewsletterSubscriptions.js
@@ -172,7 +172,6 @@ const NewsletterSubscriptions = ({ t, userId }) => {
                             <div>
                               <TextButton
                                 disabled={loading}
-                                {...colorScheme.set('color', 'primary')}
                                 onClick={() => {
                                   const answer = confirm(
                                     'Wollen Sie die Newsletter für diesen Benutzer reaktivieren?\nDer Benutzer wird eine E-Mail erhalten, um die Reaktivierung zu bestätigen.'
@@ -181,7 +180,9 @@ const NewsletterSubscriptions = ({ t, userId }) => {
                                     mutate({ variables: { userId: user.id } })
                                 }}
                               >
-                                reaktivieren
+                                <span {...colorScheme.set('color', 'primary')}>
+                                  reaktivieren
+                                </span>
                               </TextButton>
                               {loading && <InlineSpinner size={22} />}
                             </div>

--- a/components/Users/NewsletterSubscriptions.js
+++ b/components/Users/NewsletterSubscriptions.js
@@ -153,7 +153,7 @@ const NewsletterSubscriptions = ({ t, userId }) => {
                   <SectionTitle>Abonnierte Newsletter</SectionTitle>
                   <div>
                     <span style={{ marginRight: 10 }}>Status: {status}</span>
-                    {status === 'unsubscribed' && (
+                    {status !== 'subscribed' && (
                       <Mutation mutation={RESUBSCRIBE_EMAIL}>
                         {(mutate, { loading, error }) => {
                           if (error) return <ErrorMessage error={error} />


### PR DESCRIPTION
## Changes

- If the newsletter-settings of a user is not "subscribed" a reactivate-button is shown next to the status.
- Once the button is clicked, a prompt appears that informs the user that an email will be sent. The user then has the option to confirm or decline the reactivation.

## Screenshots

### Added button

<img width="316" alt="Screenshot 2021-08-05 at 09 45 55" src="https://user-images.githubusercontent.com/30313631/128318774-a7d2b0d7-d11a-48c7-8943-08eb811d9e97.png">


### Prompt once the button has been clicked

<img width="478" alt="Screenshot 2021-08-05 at 09 46 06" src="https://user-images.githubusercontent.com/30313631/128318842-7b4d6298-ba3c-432d-8077-db38d6908066.png">
