### PR TITLE
fix(Zat): Improved Admin-Tool widget data

### DIFF
--- a/components/Tables/utils.js
+++ b/components/Tables/utils.js
@@ -67,9 +67,7 @@ export const tableStyles = {
     textAlign: 'center'
   }),
   paddedCell: css({
-    padding: '15px 2px',
-    overflowWrap: 'anywhere',
-    whiteSpace: 'normal'
+    padding: '15px 2px'
   })
 }
 

--- a/components/Zat/Mails.js
+++ b/components/Zat/Mails.js
@@ -26,7 +26,7 @@ const Mails = ({ mails }) => {
     <div>
       {mails.map(mail => {
         return (
-          <div key={mail.key} {...styles.mail}>
+          <div key={mail.id} {...styles.mail}>
             <div>
               <Date mail={mail} />
             </div>

--- a/components/Zat/User/AccessGrants.js
+++ b/components/Zat/User/AccessGrants.js
@@ -1,0 +1,27 @@
+import React from 'react'
+import gql from 'graphql-tag'
+
+import { displayDate } from '../../Display/utils'
+import { styles } from '../utils'
+
+export const fragments = gql`
+  fragment UserAccessGrants on User {
+    accessGrants {
+      id
+      endAt
+    }
+  }
+`
+
+export const AccessGrants = ({ accessGrants }) =>
+  accessGrants?.map(accessGrant => {
+    const { id, endAt } = accessGrant
+
+    return (
+      <div key={id} {...styles.part}>
+        Access Grant bis {displayDate(endAt)}
+      </div>
+    )
+  })
+
+export default AccessGrants

--- a/components/Zat/User/Memberships.js
+++ b/components/Zat/User/Memberships.js
@@ -1,0 +1,78 @@
+import React from 'react'
+import gql from 'graphql-tag'
+
+import { displayDate } from '../../Display/utils'
+import { styles } from './../utils'
+
+export const fragments = gql`
+  fragment UserMemberships on User {
+    activeMembership {
+      type {
+        name
+      }
+      overdue
+      renew
+    }
+    memberships {
+      id
+      periods {
+        beginDate
+        endDate
+      }
+    }
+  }
+`
+
+const getLastPeriod = periods =>
+  periods?.reduce((accumulator, currentValue) => {
+    return !accumulator || currentValue.endDate > accumulator.endDate
+      ? currentValue
+      : accumulator
+  }, false)
+
+const getFirstPeriod = periods =>
+  periods?.reduce((accumulator, currentValue) => {
+    return !accumulator || currentValue.beginDate < accumulator.beginDate
+      ? currentValue
+      : accumulator
+  }, false)
+
+export const Memberships = ({ activeMembership, memberships }) => {
+  const periods = memberships?.map(m => m.periods).flat()
+
+  const lastPeriod = getLastPeriod(periods)
+
+  if (!activeMembership) {
+    return (
+      lastPeriod && (
+        <div {...styles.part}>
+          ehemalig{' · '}bis {displayDate(lastPeriod.endDate)}
+        </div>
+      )
+    )
+  }
+
+  const firstPeriod = getFirstPeriod(periods)
+
+  return (
+    <div {...styles.part}>
+      {activeMembership.type?.name}
+      {!activeMembership.renew && <>{' · '}gekündigt</>}
+      {!!activeMembership.overdue && !!activeMembership.renew && (
+        <>{' · '}überfällig</>
+      )}
+      {lastPeriod && (
+        <>
+          {' · '}bis {displayDate(lastPeriod.endDate)}
+        </>
+      )}
+      {firstPeriod && (
+        <>
+          {' · '}dabei seit {displayDate(firstPeriod.beginDate)}
+        </>
+      )}
+    </div>
+  )
+}
+
+export default Memberships

--- a/components/Zat/User/NewsletterSettings.js
+++ b/components/Zat/User/NewsletterSettings.js
@@ -1,0 +1,43 @@
+import React from 'react'
+import gql from 'graphql-tag'
+
+import withT from '../../../lib/withT'
+import { styles } from './../utils'
+
+export const fragments = gql`
+  fragment UserNewsletterSettings on User {
+    newsletterSettings {
+      status
+      subscriptions {
+        name
+        subscribed
+      }
+    }
+  }
+`
+
+export const NewsletterSettings = ({ newsletterSettings, t }) => {
+  const newsletterNames = newsletterSettings?.subscriptions
+    ?.filter(subscription => subscription.subscribed)
+    .map(subscription =>
+      t(
+        `account/newsletterSubscriptions/${subscription.name}/label`,
+        undefined,
+        subscription.name
+      )
+    )
+
+  return (
+    <div {...styles.part}>
+      Newsletter{' '}
+      {newsletterSettings?.status && <>({newsletterSettings?.status})</>}
+      {!!newsletterNames.length && ' · '}
+      {newsletterNames
+        .map(name => name)
+        .filter(Boolean)
+        .join(' · ')}
+    </div>
+  )
+}
+
+export default withT(NewsletterSettings)

--- a/components/Zat/User/Sessions.js
+++ b/components/Zat/User/Sessions.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import gql from 'graphql-tag'
+
+import { styles } from '../utils'
+
+export const fragments = gql`
+  fragment UserSessions on User {
+    sessions {
+      id
+      userAgent
+    }
+  }
+`
+
+export const Sessions = ({ sessions }) =>
+  !!sessions?.length && (
+    <div {...styles.part}>
+      {sessions.map(({ id, userAgent }) => (
+        <div key={id}>{userAgent}</div>
+      ))}
+    </div>
+  )
+
+export default Sessions

--- a/components/Zat/utils.js
+++ b/components/Zat/utils.js
@@ -3,16 +3,26 @@ import { fontStyles, colors } from '@project-r/styleguide'
 import { css } from 'glamor'
 
 export const styles = {
+  info: css({
+    borderBottom: '1px solid #DDD',
+    paddingBottom: 5,
+    marginBottom: 5,
+    ...fontStyles.sansSerifRegular14
+  }),
   hint: css({
     borderBottom: '1px solid #DDD',
-    marginBottom: '10px',
-    paddingBottom: '10px',
+    paddingBottom: 10,
+    marginBottom: 10,
     ...fontStyles.sansSerifRegular14
   }),
   item: css({
     borderBottom: '1px solid #DDD',
-    marginBottom: '10px',
-    paddingBottom: '10px'
+    marginBottom: 5,
+    paddingBottom: 5
+  }),
+  part: css({
+    marginTop: 10,
+    marginBottom: 10
   }),
   title: css({
     marginTop: '10px'

--- a/pages/zat.js
+++ b/pages/zat.js
@@ -34,7 +34,7 @@ const Zat = props => {
   const [searchEmail, setSearchEmail] = useState(null)
   const [searchName, setSearchName] = useState(null)
 
-  const { origin, app_guid } = props.router.query
+  const { origin, app_guid, email, name } = props.router.query
 
   useEffect(() => {
     if (typeof window !== 'undefined' && origin && app_guid) {
@@ -49,6 +49,18 @@ const Zat = props => {
       fetchZafContext()
     }
   }, [origin, app_guid])
+
+  useEffect(() => {
+    if (email) {
+      setSearchEmail(email)
+    }
+  }, [email])
+
+  useEffect(() => {
+    if (name) {
+      setSearchName(name)
+    }
+  }, [name])
 
   useEffect(() => {
     if (zafContext) {
@@ -102,7 +114,11 @@ const Zat = props => {
                 error={error}
                 render={() => (
                   <>
-                    <Users email={searchEmail} users={data.adminUsers?.items} />
+                    <Users
+                      email={searchEmail}
+                      name={searchName}
+                      users={data.adminUsers?.items}
+                    />
                     <Mails mails={data.mailbox?.nodes} />
                   </>
                 )}


### PR DESCRIPTION
Provides more info on memberships – cancelled, member since, etc.

![Bildschirmfoto am 2021-09-23 um 18 06 58](https://user-images.githubusercontent.com/331800/134544616-89c7930f-6f36-4c52-a01a-96533ba00a8f.png)

Shows if an access grant is active:

![Bildschirmfoto am 2021-09-23 um 18 08 03](https://user-images.githubusercontent.com/331800/134544735-c5c4388c-a395-4e28-8ec4-7cd57327f519.png)

Improves no-user-found notice – includes email or name not found:

![Bildschirmfoto am 2021-09-23 um 18 08 21](https://user-images.githubusercontent.com/331800/134544786-03757a66-0e2a-4ae4-ab5d-52f79d281cef.png)
![Bildschirmfoto am 2021-09-23 um 18 09 24](https://user-images.githubusercontent.com/331800/134544789-618fcf79-0cc0-4867-ab1b-21c78a5c65ab.png)

Reverts a style error:

<img width="385" alt="Bildschirmfoto 2021-09-23 um 18 04 30" src="https://user-images.githubusercontent.com/331800/134544574-a174c4a1-6fde-4aad-bb6e-475b937edf02.png">

For development purposes, `/zat` accepts query paremters `email` and `name`.